### PR TITLE
The game ends when escape key is pressed

### DIFF
--- a/NoMansRay/NoMansRay.cpp
+++ b/NoMansRay/NoMansRay.cpp
@@ -154,6 +154,13 @@ void handleEvents()
 	while (SDL_PollEvent(&event))
 	{
 		switch (event.type) {
+		case SDL_KEYDOWN:
+		{
+			if (event.key.keysym.sym == SDLK_ESCAPE) {
+				is_running = false;
+			}
+			break;
+		}
 		case SDL_QUIT:
 			is_running = false;
 			break;


### PR DESCRIPTION
Simply, modified the handle events function to check for a keypress event. If the key that was pressed was an escape key then the game will end.