### PR TITLE
Refactor object into actor

### DIFF
--- a/NoMansRay/Actor.cpp
+++ b/NoMansRay/Actor.cpp
@@ -16,8 +16,26 @@ Actor::Actor(Universe& universe) :
 	physics_fixture_def_{},
 	density_{0.f},
 	friction_{0.f},
-	restitution_{0.f}
+	restitution_{0.f},
+	position_{},
+	linear_velocity_{},
+	rotation_radians_{ ZERO_DECIMAL },
+	angular_velocity_{ ZERO_DECIMAL },
+	scale_{ ONE_DECIMAL, ONE_DECIMAL },
+	transform_changed_{ true }
 {}
+
+void Actor::initialize(const SpawnParameters& spawn_parameters)
+{
+	position_ = spawn_parameters.position;
+	linear_velocity_ = spawn_parameters.linear_velocity;
+	rotation_radians_ = spawn_parameters.rotation_radians;
+	angular_velocity_ = spawn_parameters.angular_velocity;
+	name_ = spawn_parameters.name;
+}
+
+void Actor::initializePhysics()
+{ }
 
 void Actor::initializePhysics(b2BodyType bodyType)
 {
@@ -134,4 +152,53 @@ void Actor::setRotation(const decimal& new_rotation)
 		rotation_radians_ = new_rotation;
 		vertex_transforms_valid_ = false;
 	}
+}
+
+// Setters
+void Actor::setPosition(const Vector2<decimal>& new_position)
+{
+	position_ = new_position;
+}
+
+void Actor::setPosition(decimal x, decimal y)
+{
+	position_.set_x(x);
+	position_.set_y(y);
+}
+
+void Actor::setLinearVelocity(decimal x, decimal y)
+{
+	linear_velocity_.set_x(x);
+	linear_velocity_.set_y(y);
+}
+
+void Actor::setLinearVelocity(const Vector2<decimal>& new_linear_velocity)
+{
+	linear_velocity_ = new_linear_velocity;
+}
+
+void Actor::setAngularVelocity(const decimal& new_angular_velocity)
+{
+	angular_velocity_ = new_angular_velocity;
+}
+
+// Getters
+const Vector2<decimal>& Actor::getPosition()
+{
+	return position_;
+}
+
+const Vector2<decimal>& Actor::getLinearVelocity()
+{
+	return linear_velocity_;
+}
+
+const decimal& Actor::getRotation()
+{
+	return rotation_radians_;
+}
+
+const decimal& Actor::getAngularVelocity()
+{
+	return angular_velocity_;
 }

--- a/NoMansRay/Actor.h
+++ b/NoMansRay/Actor.h
@@ -21,21 +21,47 @@ protected:
 	decimal density_;
 	decimal friction_;
 	decimal restitution_;
+	Vector2<decimal> position_;
+	Vector2<decimal> linear_velocity_;
+	decimal rotation_radians_;
+	decimal angular_velocity_;
+	Vector2<decimal> scale_;
+	bool transform_changed_;
 
+	virtual void updateVertexTransforms();
 public:
 	Actor() = delete;
 	Actor(Universe& universe);
 	~Actor() = default;
 
-	virtual void addVertex(const Vector2<decimal>& coordinates);
-	virtual void addLine(uint32_t vertex_0, uint32_t vertex_1);
-	void setRotation(const decimal& new_rotation) override;
-	virtual const LineVector& getLines() const;
+	virtual void initialize(const SpawnParameters& spawn_parameters);
+
+	// Getters
 	virtual const VertexVector& getVertices();
 	virtual const Vector2<decimal>* getVertexById(uint32_t vertex_id);
-	eGraphicType getGraphicType() const;
-	void initializePhysics(b2BodyType bodyType);
-	void initializePhysics(b2BodyType bodyType, decimal density, decimal friction, decimal restitution);
-	void updatePhysics(decimal seconds_elapsed);
-	void updateVertexTransforms();
+	virtual eGraphicType getGraphicType() const;
+	virtual const LineVector& getLines() const;
+
+	virtual const Vector2<decimal>& getPosition();
+	virtual const Vector2<decimal>& getLinearVelocity();
+	virtual const decimal& getRotation();
+	virtual const decimal& getAngularVelocity();
+
+	// Setters
+	virtual void setPosition(const Vector2<decimal>& new_position);
+	virtual void setPosition(decimal x, decimal y);
+	virtual void setLinearVelocity(const Vector2<decimal>& new_linear_velocity);
+	virtual void setLinearVelocity(decimal x, decimal y);
+	virtual void setRotation(const decimal& new_rotation);
+	virtual void setAngularVelocity(const decimal& new_angular_velocity);
+
+	// Modifiers
+	virtual void addVertex(const Vector2<decimal>& coordinates);
+	virtual void addLine(uint32_t vertex_0, uint32_t vertex_1);
+
+	// Physics
+	virtual void initializePhysics();
+	virtual void initializePhysics(b2BodyType bodyType);
+	virtual void initializePhysics(b2BodyType bodyType, decimal density, decimal friction, decimal restitution);
+	virtual void updatePhysics(decimal seconds_elapsed);
 };

--- a/NoMansRay/Asteroid.cpp
+++ b/NoMansRay/Asteroid.cpp
@@ -14,7 +14,17 @@ Asteroid::Asteroid(Universe& universe) :
 
 }
 
+void Asteroid::beginPlay()
+{
+
+}
+
 void Asteroid::tick(decimal seconds_elapsed)
+{
+
+}
+
+void Asteroid::endPlay()
 {
 
 }
@@ -88,9 +98,18 @@ void Asteroid::triangulate()
 		fixture_def.restitution = restitution_;
 		physics_body_->CreateFixture(&fixture_def);
 	}
+}
 
-	physics_body_->ApplyLinearImpulse({ physics_body_->GetMass() * linear_velocity_.x(), physics_body_->GetMass() * linear_velocity_.y() }, { position_.x(), position_.y() }, true);
-	physics_body_->ApplyAngularImpulse(physics_body_->GetMass() * angular_velocity_, true);
+
+void Asteroid::updatePhysics(decimal seconds_elapsed)
+{
+	Actor::updatePhysics(seconds_elapsed);
+
+	if (!physics_is_setup_) {
+		physics_body_->ApplyLinearImpulseToCenter({ physics_body_->GetMass() * linear_velocity_.x(), physics_body_->GetMass() * linear_velocity_.y() }, true);
+		physics_body_->ApplyAngularImpulse(physics_body_->GetMass() * angular_velocity_, true);
+		physics_is_setup_ = true;
+	}
 }
 
 void Asteroid::addLinesFromTriangles(const std::vector<Triangle>& triangles)
@@ -118,7 +137,7 @@ void Asteroid::addLinesFromTriangles(const std::vector<Triangle>& triangles)
 
 void Asteroid::initialize(const SpawnParameters& spawn_parameters)
 {
-	Object::initialize(spawn_parameters);
+	Actor::initialize(spawn_parameters);
 	initialize();
 }
 

--- a/NoMansRay/Asteroid.h
+++ b/NoMansRay/Asteroid.h
@@ -9,6 +9,7 @@ private:
 	static constexpr uint16_t MIN_RADIUS = 50;
 	static constexpr uint16_t MAX_RADIUS = 150;
 	std::unique_ptr<Delaunay> delaunay_;
+	bool physics_is_setup_ = false;
 	void generate();
 	void triangulate();
 	void addLinesFromTriangles(const std::vector<Triangle>& triangles);
@@ -18,5 +19,8 @@ public:
 	~Asteroid() = default;
 	void initialize(const SpawnParameters& spawn_parameters) override;
 	void initialize() override;
+	void beginPlay() override;
 	void tick(decimal seconds_elapsed) override;
+	void endPlay() override;
+	void updatePhysics(decimal seconds_elapsed) override;
 };

--- a/NoMansRay/NoMansRay.cpp
+++ b/NoMansRay/NoMansRay.cpp
@@ -85,9 +85,12 @@ int main()
 	SDL_ShowWindow(window);
 	SDL_RenderFillRect(renderer, NULL);
 
-	auto asteroid1 = universe->spawnActor<Asteroid>({ { 0.f, 0.f }, { 0.1f, 500.f }, 0.f, 50.f, "Asteroid_1" });
-	auto asteroid2 = universe->spawnActor<Asteroid>({ {-100.0, 300.0}, {0.1f, 500.f}, 0.f, 30.f , "Asteroid_2" });
-	auto asteroid3 = universe->spawnActor<Asteroid>({ {100.0, 300.0}, {0.5f, 500.f}, 0.f, 60.f , "Asteroid_3" });
+	auto asteroid1 = universe->spawnActor<Asteroid>({ { 0.f, 0.f }, { 100.f, 100.f }, 0.f, 50.f, "Asteroid_1" });
+	auto asteroid2 = universe->spawnActor<Asteroid>({ {-100.0, 300.0}, {-50.f, -100.f}, 0.f, 30.f , "Asteroid_2" });
+	auto asteroid3 = universe->spawnActor<Asteroid>({ {100.0, 300.0}, {0.5f, -30.f}, 0.f, 60.f , "Asteroid_3" });
+	auto asteroid4 = universe->spawnActor<Asteroid>({ {-100.0, -300.0}, {0.5f, 200.f}, 0.f, 60.f , "Asteroid_3" });
+
+	universe->beginPlay();
 
 	audio_manager->playMusic(0);
 	audio_manager->playSound(0);
@@ -101,6 +104,8 @@ int main()
 			break;
 		}
 	}
+
+	universe->endPlay();
 
 	// frees memory associated with renderer and window
 	SDL_DestroyRenderer(renderer);

--- a/NoMansRay/Object.cpp
+++ b/NoMansRay/Object.cpp
@@ -1,13 +1,7 @@
 #include "Object.h"
 
 Object::Object(Universe& universe) : 
-	universe_{ universe },
-	position_{},
-	linear_velocity_{},
-	rotation_radians_{ ZERO_DECIMAL },
-	angular_velocity_{ ZERO_DECIMAL },
-	scale_{ ONE_DECIMAL, ONE_DECIMAL },
-	transform_changed_ { true }
+	universe_{ universe }
 { }
 
 void Object::beginPlay()
@@ -25,75 +19,17 @@ void Object::endPlay()
 
 }
 
-void Object::initialize(const SpawnParameters& spawn_parameters)
+void Object::initialize(const std::string& name)
 {
-	position_ = spawn_parameters.position;
-	linear_velocity_ = spawn_parameters.linear_velocity;
-	rotation_radians_ = spawn_parameters.rotation_radians;
-	angular_velocity_ = spawn_parameters.angular_velocity;
-	name_ = spawn_parameters.name;
+	name_ = name;
 }
 
 void Object::initialize()
 { }
 
-// Setters
-void Object::setPosition(const Vector2<decimal>& new_position)
-{
-	position_ = new_position;
-}
-
-void Object::setPosition(decimal x, decimal y)
-{
-	position_.set_x(x);
-	position_.set_y(y);
-}
-
-void Object::setLinearVelocity(decimal x, decimal y)
-{
-	linear_velocity_.set_x(x);
-	linear_velocity_.set_y(y);
-}
-
-void Object::setLinearVelocity(const Vector2<decimal>& new_linear_velocity)
-{
-	linear_velocity_ = new_linear_velocity;
-}
-
-void Object::setRotation(const decimal& new_rotation)
-{
-	rotation_radians_ = new_rotation;
-}
-
-void Object::setAngularVelocity(const decimal& new_angular_velocity)
-{
-	angular_velocity_ = new_angular_velocity;
-}
-
 void Object::setName(const std::string& name)
 {
 	name_ = name;
-}
-
-// Getters
-const Vector2<decimal>& Object::getPosition()
-{
-	return position_;
-}
-
-const Vector2<decimal>& Object::getLinearVelocity()
-{
-	return linear_velocity_;
-}
-
-const decimal& Object::getRotation()
-{
-	return rotation_radians_;
-}
-
-const decimal& Object::getAngularVelocity()
-{
-	return angular_velocity_;
 }
 
 const std::string Object::getName()

--- a/NoMansRay/Object.h
+++ b/NoMansRay/Object.h
@@ -8,12 +8,6 @@ class Object
 {
 protected:
 	Universe& universe_;
-	Vector2<decimal> position_;
-	Vector2<decimal> linear_velocity_;
-	decimal rotation_radians_;
-	decimal angular_velocity_;
-	Vector2<decimal> scale_;
-	bool transform_changed_;
 	std::string name_;
 public:
 	Object() = delete;
@@ -23,22 +17,12 @@ public:
 	virtual void beginPlay();
 	virtual void tick(decimal seconds_elapsed);
 	virtual void endPlay();
-	virtual void initialize(const SpawnParameters& spawn_parameters);
+	virtual void initialize(const std::string& spawn_parameters);
 	virtual void initialize();
-	
+
 	// Setters
-	virtual void setPosition(const Vector2<decimal>& new_position);
-	virtual void setPosition(decimal x, decimal y);
-	virtual void setLinearVelocity(const Vector2<decimal>& new_linear_velocity);
-	virtual void setLinearVelocity(decimal x, decimal y);
-	virtual void setRotation(const decimal& new_rotation);
-	virtual void setAngularVelocity(const decimal& new_angular_velocity);
 	virtual void setName(const std::string& name);
 
 	// Getters
-	virtual const Vector2<decimal>& getPosition();
-	virtual const Vector2<decimal>& getLinearVelocity();
-	virtual const decimal& getRotation();
-	virtual const decimal& getAngularVelocity();
 	virtual const std::string getName();
 };

--- a/NoMansRay/Universe.cpp
+++ b/NoMansRay/Universe.cpp
@@ -37,17 +37,34 @@ void Universe::tick()
 		it++;
 	}
 
-	physics.ClearForces();
+	//physics.ClearForces();
 
 	last_tick_time_ = now;
 }
 
-void Universe::endExistance()
+void Universe::beginPlay()
+{
+	physics.Step(1 / 60.f, physics_settings_.velocity_iterations, physics_settings_.position_iterations);
+
+	ActorIdMap::iterator it = actor_map_.begin();
+
+	while (it != actor_map_.end()) {
+		auto actor = it->second;
+
+		if (actor) {
+			actor->beginPlay();
+		}
+
+		it++;
+	}
+}
+
+void Universe::endPlay()
 {
 	ActorIdMap::iterator it = actor_map_.begin();
 
 	while (it != actor_map_.end()) {
-		auto& actor = it->second;
+		auto actor = it->second;
 
 		if (actor) {
 			actor->endPlay();

--- a/NoMansRay/Universe.cpp
+++ b/NoMansRay/Universe.cpp
@@ -64,15 +64,15 @@ void Universe::endPlay()
 	ActorIdMap::iterator it = actor_map_.begin();
 
 	while (it != actor_map_.end()) {
+		auto id = it->first;
 		auto actor = it->second;
+		it++;
 
 		if (actor) {
 			actor->endPlay();
 			delete actor;
-			actor_map_.erase(it->first);
+			actor_map_.erase(id);
 		}
-
-		it++;
 	}
 }
 

--- a/NoMansRay/Universe.h
+++ b/NoMansRay/Universe.h
@@ -44,8 +44,9 @@ public:
 
 	b2World* getPhysics();
 
+	void beginPlay();
+	void endPlay();
 	void tick();
-	void endExistance();
 };
 
 #include "Universe.inl"

--- a/NoMansRay/Universe.inl
+++ b/NoMansRay/Universe.inl
@@ -12,7 +12,7 @@ Actor* spawnActor(
 template <class T>
 Actor* Universe::spawnActor(const SpawnParameters& spawn_parameters)
 {
-	static_assert(std::is_convertible<T*, Actor*>::value, "Derived must inherit Base as public");
+	static_assert(std::is_convertible<T*, Actor*>::value, "Derived must inherit Actor as public");
 	Actor* new_actor = static_cast<Actor*>(new T(*this));
 	new_actor->initialize(spawn_parameters);
 	last_id_++;


### PR DESCRIPTION
There was a significant amount of physics-related code in Object.
In theory, Object should be kept absolutely minimal, no physics. Physics should be handled at the Actor level instead.
A bug that caused the universe to crash on endPlay was fixed, related to the iterator going null when the object it is pointing to being erased.